### PR TITLE
feat: Trackpad Bellows Support

### DIFF
--- a/LidAngleSensor/AppDelegate.m
+++ b/LidAngleSensor/AppDelegate.m
@@ -80,6 +80,20 @@ static const int kKeyToMidiNote[] = {
     if (midiNote > 0) {
         [self.harmoniumEngine releaseNote:midiNote];
     }
+
+}
+
+- (void)keyCaptureView:(KeyCaptureView *)view didScrollWithDelta:(CGFloat)deltaY {
+    // Only allow manual pumping if the "Max Air" toggle is OFF
+    if (self.airPressureToggle.state == NSControlStateValueOff) {
+        // Sensitivity factor - adjust to taste. 0.05 provides a reasonable feel.
+        CGFloat pumpAmount = fabs(deltaY) * 0.05;
+        self.airPressure += pumpAmount;
+        self.airPressure = fminf(1.0, self.airPressure); // Clamp to max 1.0
+        
+        // Ensure lastUpdateTime is updated effectively in the main loop, 
+        // but explicit modification here isn't strictly necessary as the main loop handles decay.
+    }
 }
 
 
@@ -127,7 +141,7 @@ static const int kKeyToMidiNote[] = {
     self.legendLabel.stringValue = @"-";
     
     self.instructionsLabel = [[NSLabel alloc] init];
-    self.instructionsLabel.stringValue = @"Move the lid to pump the bellows or use the 'Max Air' toggle.";
+    self.instructionsLabel.stringValue = @"Move lid or scroll to pump bellows, or use 'Max Air'.";
     self.instructionsLabel.alignment = NSTextAlignmentCenter;
     
     // Add ALL views to the content view

--- a/LidAngleSensor/KeyCaptureView.h
+++ b/LidAngleSensor/KeyCaptureView.h
@@ -13,6 +13,7 @@
 @protocol KeyCaptureViewDelegate <NSObject>
 - (void)keyCaptureView:(KeyCaptureView *)view didReceiveKeyDown:(NSEvent *)event;
 - (void)keyCaptureView:(KeyCaptureView *)view didReceiveKeyUp:(NSEvent *)event;
+- (void)keyCaptureView:(KeyCaptureView *)view didScrollWithDelta:(CGFloat)deltaY;
 @end
 
 @interface KeyCaptureView : NSView

--- a/LidAngleSensor/KeyCaptureView.m
+++ b/LidAngleSensor/KeyCaptureView.m
@@ -28,4 +28,11 @@
     [self.delegate keyCaptureView:self didReceiveKeyUp:event];
 }
 
+- (void)scrollWheel:(NSEvent *)event {
+    // Forward the scrolling delta to the delegate
+    if ([self.delegate respondsToSelector:@selector(keyCaptureView:didScrollWithDelta:)]) {
+        [self.delegate keyCaptureView:self didScrollWithDelta:event.scrollingDeltaY];
+    }
+}
+
 @end


### PR DESCRIPTION
Implements 'Trackpad Bellows' to allow users to simulate air pressure using the scroll gesture.
This enables the app to be used on MacBooks without the specific lid angle sensor or on unsupported hardware.

Changes:
- Added `scrollWheel:` handling in `KeyCaptureView`.
- Implemented air pressure logic in `AppDelegate`.
- Updated UI instructions.